### PR TITLE
Fix k82f hardware AES compilation

### DIFF
--- a/k82f/k82f_hal.c
+++ b/k82f/k82f_hal.c
@@ -16,7 +16,7 @@
 #define ROUNDS_BEFORE_RESEED 50000
 #define AES_KEY_SIZE 16
 
-static uint32_t AES_KEY_SCH[44];
+static uint8_t AES_KEY_SCH[44];
 static char ltcAesKey[AES_KEY_SIZE];
 static uint32_t maskSeed;
 static uint32_t nbAesBlocks;


### PR DESCRIPTION
For some reason the keyschedule was 4 times too big and compilation fails because `uint8_t*` is expected by the LTC API.

44 bytes matches with AES128