### PR TITLE
add extern uint32_t HAL_GetTick(void); in stm32f4

### DIFF
--- a/stm32f4/stm32f4xx_hal_rng.c
+++ b/stm32f4/stm32f4xx_hal_rng.c
@@ -60,6 +60,8 @@
 //#include "stm32f4xx_hal.h"
 #include "stm32f4xx_hal_rng.h"
 
+extern uint32_t HAL_GetTick(void);
+
 /** @addtogroup STM32F4xx_HAL_Driver
   * @{
   */


### PR DESCRIPTION
If you rm '-Wno-implicit-function-declaration' in cw/firmware/mcu/Makefile.inc in commit 00795e969cb1b48afbc46638accbc6878ac64e4e (newaetech/chipwhisperer), then when compiling stm32f4, it would fail with error:
  'HAL_GetTick' [-Wimplicit-function-declaration]
This commit solves the issue.